### PR TITLE
Fix deprecation notice

### DIFF
--- a/src/Composer/Util/GitHub.php
+++ b/src/Composer/Util/GitHub.php
@@ -101,7 +101,7 @@ class GitHub
         $this->io->writeError(sprintf('Tokens will be stored in plain text in "%s" for future use by Composer.', $this->config->getAuthConfigSource()->getName()));
         $this->io->writeError('For additional information, check https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth');
 
-        $token = trim($this->io->askAndHideAnswer('Token (hidden): '));
+        $token = trim($this->io->askAndHideAnswer('Token (hidden): ') ?? '');
 
         if (!$token) {
             $this->io->writeError('<warning>No token given, aborting.</warning>');


### PR DESCRIPTION
Deprecation Notice: trim(): Passing null to parameter #1 ($string) of type string is deprecated in phar:///usr/bin/composer/src/Composer/Util/GitHub.php:103
